### PR TITLE
Updates submit button in shippingMethod checkout

### DIFF
--- a/partials/shop-checkout-shippingmethod.htm
+++ b/partials/shop-checkout-shippingmethod.htm
@@ -70,9 +70,9 @@
 
                             {% if shippingOptions %}
                             <div class="pull-right">
-                                <button type="submit" class="btn btn-primary" data-ajax-handler="shop:checkout" data-ajax-update="#checkout-page=shop-checkout, #mini-cart=shop-minicart">
+                                <a class="btn btn-primary" data-ajax-handler="shop:checkout" data-ajax-update="#checkout-page=shop-checkout, #mini-cart=shop-minicart">
                                 Order Review &nbsp; <i class="icon-chevron-right"></i>
-                                </button>
+                                </a>
                             </div>
                             {% endif %}
 


### PR DESCRIPTION
Every checkout step in Laboutique uses link "a" tags to submit form content, except for the shipping method. The issue with the "button" is that it submits everything inbetween its tags, and the response is empty checkout values, empty cart, etc:
(no shipping method, 200 response)
![checkout___la_boutique](https://cloud.githubusercontent.com/assets/14319209/18217402/7b573358-7111-11e6-9ed9-724d0c4abbc6.png)

Using an `<input type="submit">` fixes the issue, or an `<a>`
