### PR TITLE
corrected shippingInfo company typo

### DIFF
--- a/partials/shop-checkout-shipping-address.htm
+++ b/partials/shop-checkout-shipping-address.htm
@@ -64,7 +64,7 @@
                                     <div class="control-group">
                                         <label for="company" class="control-label">Company</label>
                                         <div class="controls">
-                                            <input class="span12" type="text" value="{{ shippingInfo.company }}" name="shippingInfo[phone]" id="company" />
+                                            <input class="span12" type="text" value="{{ shippingInfo.company }}" name="shippingInfo[company]" id="company" />
                                         </div>
                                     </div>
                                     <div class="control-group">


### PR DESCRIPTION
https://github.com/lemonstand/lemonstand-2/issues/2941

`name="shippingInfo[company]"`
