### PR TITLE
Total cleanup (Cart Items, Receipt)

### DIFF
--- a/partials/shop-cart-content.htm
+++ b/partials/shop-cart-content.htm
@@ -129,10 +129,10 @@
                             <h5>Shipping costs and taxes will be evaluated during checkout</h5>
                         </div>
                         <ul class="price-list">
-                            {% if totals.discountTotal > 0 %}
-                                <li>Discount: <strong>{{ totals.discountTotal|currency }}</strong></li>
-                            {% endif %}
                             <li>Subtotal: <strong>{{ totals.subtotal|currency }}</strong></li>
+                            {% if totals.discountTotal > 0 %}
+                                <li>Discount: <strong>- {{ totals.discountTotal|currency }}</strong></li>
+                            {% endif %}
                             {% if totals.totalShippingQuote > 0 %}
                                 <li>Shipping: <strong>{{ totals.totalShippingQuote|currency }}</strong></li>
                             {% endif %}

--- a/partials/shop-cart-items.htm
+++ b/partials/shop-cart-items.htm
@@ -60,7 +60,7 @@
                         </td>
     
                         <td data-title="Discount" class="col_discount text-right">
-                            <span class="discount">{{ ((item.quantity * item.product.price) - item.total())|currency }}</span>
+                            <span class="discount">- {{ ((item.quantity * item.product.price) - item.total())|currency }}</span>
                             
                         </td>
     

--- a/partials/shop-invoiceitems.htm
+++ b/partials/shop-invoiceitems.htm
@@ -43,11 +43,11 @@
                         <td data-title="Qty" class="col_qty text-right">{{ item.quantity|number_format(0) }}</td>
                         
                         <td data-title="Single" class="col_single text-right">
-                            <span class="single-price">{{ item.pivot.price|currency }}</span>
+                            <span class="single-price">{{ item.product.price|currency }}</span>
                         </td>
     
                         <td data-title="Discount" class="col_discount text-right">
-                            <span class="discount">{{ 0|currency }}</span>
+                            <span class="discount">- {{ ((item.quantity * item.product.price) - item.total())|currency }}</span>
                         </td>
     
                         <td data-title="Total" class="col_total text-right">

--- a/partials/shop-invoicetotals.htm
+++ b/partials/shop-invoicetotals.htm
@@ -3,10 +3,10 @@
             <h3>Order total</h3>
         </div>
         <ul class="price-list">
-            {% if invoice.total_discount %}
-                <li>Discount: <strong>{{ invoice.total_discount|currency }}</strong></li>
-            {% endif %}
             <li>Subtotal: <strong>{{ invoice.subtotal|currency }}</strong></li>
+            {% if invoice.total_discount %}
+                <li>Discount: <strong>- {{ invoice.total_discount|currency }}</strong></li>
+            {% endif %}
             <li>Tax: <strong>{{ invoice.tax_total|currency }}</strong></li>
             <li>Shipping: <strong>{{ invoice.total_shipping_quote|currency }}</strong></li>
             {% if invoice.shipping_tax %}


### PR DESCRIPTION
Brought up by SoapStoneProducts: https://app.intercom.io/a/apps/7236196445273cea007287c0c90a2f0d598567cc/respond/inbox/tom@lemonstand.com/conversations/9442220938

Changes:
- Fixing $0 discount in receipt
- Cart item discount totals

## Testing
- [ ] Go through checkout, verify totals w/:
  1. Subtotal discount
  2. Cart discount
  3. Coupon/non-coupon
- [ ] Verify also receipt page